### PR TITLE
Add Game State with reducer to support phase 1

### DIFF
--- a/src/components/RemainingMen/RemainingMen.tsx
+++ b/src/components/RemainingMen/RemainingMen.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { Player } from "../../hooks/useGameState";
+import { palette } from "../../theme";
+
+export interface RemainingMenProps {
+  remainingMenCount: number;
+  player: Player;
+}
+
+export const RemainingMen: React.FC<RemainingMenProps> = (props) => {
+  const { remainingMenCount, player } = props;
+
+  const radius = 10;
+  const gap = 2 * radius;
+  const width = (radius + gap) * 7; // This magic number is the max remaining count + 1
+  const height = radius + gap;
+
+  // This could be implemented with divs and flexbox instead, but i'm on an svg bender rn so...
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
+      <rect
+        x1={0}
+        y1={0}
+        width={"100%"}
+        height={"100%"}
+        rx="5"
+        stroke={palette.neutral}
+        fillOpacity={0}
+      />
+      {new Array(remainingMenCount).fill(undefined).map((_, i) => (
+        <circle
+          cx={(i + 1) * (gap + radius)}
+          cy={"50%"}
+          r={radius}
+          fill={player === "a" ? palette.primary : palette.secondary}
+        />
+      ))}
+    </svg>
+  );
+};

--- a/src/components/app/App.css
+++ b/src/components/app/App.css
@@ -1,10 +1,24 @@
-.App-header {
+.App {
   background-color: #212121;
   min-height: 100vh;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
   justify-content: center;
   font-size: calc(10px + 2vmin);
   color: lightgrey;
+  gap: 20px;
+}
+
+.Controls {
+  background-color: #121212; /* palette.neutralDarker */
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 20px;
+  height: fit-content;
+  width: fit-content;
+  padding: 20px;
+  border-radius: 10px;
 }

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -4,14 +4,18 @@ import { palette } from "../../theme";
 
 import { Board, maxRings, minRings, ringCountDefault } from "../board";
 import { Slider } from "../Slider";
+import { useGameState } from "../../hooks/useGameState";
 
 export const App: React.FC = () => {
   const [ringCount, setRingCount] = React.useState(ringCountDefault);
+  const [gameState, updateGameState] = useGameState();
 
   return (
     <div>
       <header className="App-header">
         <h2>Morris</h2>
+
+        {/* We need to use the adjacency in gameState to assign ids to the elements drawn by this component */}
         <Board ringCount={ringCount} />
 
         {/* Temporarily adding a slider to control the number of rings */}

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -2,27 +2,24 @@ import React from "react";
 import "./App.css";
 import { palette } from "../../theme";
 
-import { Board, maxRings, minRings, ringCountDefault } from "../board";
-import { Slider } from "../Slider";
+import { Board } from "../board";
 import { useGameState } from "../../hooks/useGameState";
+import { RemainingMen } from "../RemainingMen/RemainingMen";
 
 export const App: React.FC = () => {
-  const [ringCount, setRingCount] = React.useState(ringCountDefault);
   const [gameState, updateGameState] = useGameState();
 
   return (
-    <div>
-      <header className="App-header">
-        <h2>Morris</h2>
+    <div className="App">
+      {/* We need to use the adjacency in gameState to assign ids to the elements drawn by this component */}
+      <Board
+        gameState={gameState}
+        onPlay={(play) => {
+          updateGameState(play);
+        }}
+      />
 
-        {/* We need to use the adjacency in gameState to assign ids to the elements drawn by this component */}
-        <Board
-          gameState={gameState}
-          onPlay={(play) => {
-            updateGameState(play);
-          }}
-        />
-
+      <div className="Controls">
         {/* Temporarily adding a slider to control the number of rings */}
         {/* <Slider
           min={minRings}
@@ -31,6 +28,24 @@ export const App: React.FC = () => {
           onChange={(e) => setRingCount(Number(e.target.value))}
           ringCount={ringCount}
         /> */}
+
+        <label style={{ color: palette.primary, fontSize: "larger" }}>
+          6 Man Morris
+        </label>
+
+        <label style={{ fontSize: "medium" }}>{`phase: ${gameState.phase} ${
+          gameState.phase === 2 ? "(not implemented)" : ""
+        }`}</label>
+
+        <label style={{ fontSize: "medium" }}>Remaining men:</label>
+        <RemainingMen
+          remainingMenCount={gameState.remainingMen.a}
+          player={"a"}
+        />
+        <RemainingMen
+          remainingMenCount={gameState.remainingMen.b}
+          player={"b"}
+        />
 
         {/* Temporarily add reset button for testing */}
         <button
@@ -51,34 +66,34 @@ export const App: React.FC = () => {
           href="https://github.com/Cutaiar/morris"
           target="_blank"
           rel="noopener noreferrer"
-          style={{ color: palette.primary, margin: ".83em 0" }}
+          style={{ color: palette.primary, fontSize: "medium" }}
         >
           github
         </a>
+      </div>
 
-        {/* Show raw Game State for debug */}
-        {window.location.search.includes("debug") && (
-          <div
+      {/* Show raw Game State for debug */}
+      {window.location.search.includes("debug") && (
+        <div
+          style={{
+            height: "100%",
+            overflow: "auto",
+            position: "absolute",
+            top: 0,
+            right: 20,
+          }}
+        >
+          <label>Game State</label>
+          <p
             style={{
-              height: "100%",
-              overflow: "auto",
-              position: "absolute",
-              top: 0,
-              right: 20,
+              fontSize: "small",
+              whiteSpace: "pre-wrap",
             }}
           >
-            <label>Game State</label>
-            <p
-              style={{
-                fontSize: "small",
-                whiteSpace: "pre-wrap",
-              }}
-            >
-              {JSON.stringify(gameState, null, 2)}
-            </p>
-          </div>
-        )}
-      </header>
+            {JSON.stringify(gameState, null, 2)}
+          </p>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -16,16 +16,36 @@ export const App: React.FC = () => {
         <h2>Morris</h2>
 
         {/* We need to use the adjacency in gameState to assign ids to the elements drawn by this component */}
-        <Board ringCount={ringCount} />
+        <Board
+          gameState={gameState}
+          onPlay={(play) => {
+            updateGameState(play);
+          }}
+        />
 
         {/* Temporarily adding a slider to control the number of rings */}
-        <Slider
+        {/* <Slider
           min={minRings}
           max={maxRings}
           value={ringCount}
           onChange={(e) => setRingCount(Number(e.target.value))}
           ringCount={ringCount}
-        />
+        /> */}
+
+        {/* Temporarily add reset button for testing */}
+        <button
+          style={{
+            minWidth: 60,
+            minHeight: 30,
+            backgroundColor: palette.primary,
+            color: palette.neutralLight,
+            borderRadius: 5,
+            borderStyle: "none",
+          }}
+          onClick={() => updateGameState({ type: "reset" })}
+        >
+          Reset
+        </button>
 
         <a
           href="https://github.com/Cutaiar/morris"
@@ -35,6 +55,29 @@ export const App: React.FC = () => {
         >
           github
         </a>
+
+        {/* Show raw Game State for debug */}
+        {window.location.search.includes("debug") && (
+          <div
+            style={{
+              height: "100%",
+              overflow: "auto",
+              position: "absolute",
+              top: 0,
+              right: 20,
+            }}
+          >
+            <label>Game State</label>
+            <p
+              style={{
+                fontSize: "small",
+                whiteSpace: "pre-wrap",
+              }}
+            >
+              {JSON.stringify(gameState, null, 2)}
+            </p>
+          </div>
+        )}
       </header>
     </div>
   );

--- a/src/components/board/board.tsx
+++ b/src/components/board/board.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   GameState,
   Occupancy,
+  PlaceAction,
   PlayAction,
   Point,
   PointID,
@@ -15,7 +16,7 @@ export interface BoardProps {
   /** The current state of the game including adjacency, occupancy, and turn */
   gameState: GameState;
 
-  onPlay: (play: PlayAction) => void;
+  onPlay: (play: PlayAction | PlaceAction) => void;
 }
 
 const sizeDefault = 400;
@@ -68,7 +69,7 @@ export const Board: React.FC<BoardProps> = (props) => {
   // When any point is clicked, dispatch an action noting so. // TODO: Use from
   const onClick = (pointID: PointID) => {
     console.log(pointID);
-    props.onPlay({ type: "play", from: "a", to: pointID });
+    props.onPlay({ type: "place", to: pointID });
   };
 
   // Render these three rings and the two sets of connections between them

--- a/src/components/board/board.tsx
+++ b/src/components/board/board.tsx
@@ -13,14 +13,14 @@ export interface BoardProps {
   /** pixel size of the board */
   size?: number;
 
-  /** The current state of the game including adjacency, occupancy, and turn */
+  /** The current state of the game including adjacency, occupancy, turn, and more */
   gameState: GameState;
 
+  /** Callback for when a player makes a play using the board */
   onPlay: (play: PlayAction | PlaceAction) => void;
 }
 
 const sizeDefault = 400;
-export const ringCountDefault = 3;
 
 export const maxRings = 6;
 export const minRings = 2; // TODO -- we can support 3 men morris (1 ring) by adding a center point
@@ -37,12 +37,13 @@ const validateRingCount = (ringCount: number) => {
 /**
  * Represents the morris board to be played on.
  *
- * Note: component should be used inside ErrorBoundary as it throws when props are not valid.
+ * Note: component should be used inside ErrorBoundary as it and other components inside throw.
  */
 export const Board: React.FC<BoardProps> = (props) => {
   // Provide sensible defaults if props aren't provided
   const size = props.size ?? sizeDefault;
-  // const ringCount = props.ringCount ?? ringCountDefault;
+
+  // We can calculate the number of rings based on the graph defined in state
   const numberOfPointsInRing = 8;
   const ringCount =
     Object.keys(props.gameState.stateGraph).length / numberOfPointsInRing;

--- a/src/components/board/index.ts
+++ b/src/components/board/index.ts
@@ -1,1 +1,1 @@
-export { Board, maxRings, minRings, ringCountDefault } from "./board";
+export { Board, maxRings, minRings } from "./board";

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,0 +1,64 @@
+import React from "react";
+
+type Occupancy = "a" | "b";
+type PointID = string;
+type Point = {
+  neighbors: PointID[];
+  occupancy?: Occupancy;
+};
+type StateGraph = Record<PointID, Point>;
+
+// Initial state graph just defines adjacency. occupancy is omitted as there are no pieces to start
+// This state graph represents the adjacency for 6 man morris (2 rings)
+const initialStateGraph: StateGraph = {
+  // outer ring
+  a: { neighbors: ["b", "h"] },
+  b: { neighbors: ["a", "c", "j"] },
+  c: { neighbors: ["b", "d"] },
+  d: { neighbors: ["c", "e", "l"] },
+  e: { neighbors: ["d", "f"] },
+  f: { neighbors: ["e", "g", "n"] },
+  g: { neighbors: ["f", "h"] },
+  h: { neighbors: ["g", "a", "p"] },
+
+  // inner ring
+  i: { neighbors: ["l", "p"] },
+  j: { neighbors: ["i", "k", "b"] },
+  k: { neighbors: ["j", "l"] },
+  l: { neighbors: ["k", "m", "d"] },
+  m: { neighbors: ["l", "m"] },
+  n: { neighbors: ["m", "o", "f"] },
+  o: { neighbors: ["n", "p"] },
+  p: { neighbors: ["o", "i", "h"] },
+};
+
+const initialState: GameState = { turn: 0, stateGraph: initialStateGraph };
+
+interface GameState {
+  turn: number;
+  stateGraph: StateGraph;
+}
+
+interface Action {
+  type: ActionType;
+}
+
+type ActionType = "incrementTurn" | "decrementTurn";
+
+function reducer(state: GameState, action: Action) {
+  switch (action.type) {
+    case "incrementTurn":
+      return { ...state, turn: state.turn + 1 };
+    case "decrementTurn":
+      return { ...state, turn: state.turn - 1 };
+    // TODO: Add actions which update stateGraph
+    default:
+      throw new Error(
+        `Unsupported action in encountered in useGameState: ${action}`
+      );
+  }
+}
+
+export const useGameState = () => {
+  return React.useReducer(reducer, initialState);
+};

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,6 +1,7 @@
 import React from "react";
 
-type Player = "a" | "b";
+export type Phase = 1 | 2 | 3;
+export type Player = "a" | "b";
 export type Occupancy = Player;
 export type PointID = string;
 export type Point = {
@@ -34,12 +35,16 @@ const initialStateGraph: StateGraph = {
 };
 
 const initialState: GameState = {
+  phase: 1,
   turn: { count: 0, player: "a" },
   stateGraph: initialStateGraph,
+  remainingMen: { a: 6, b: 6 },
 };
 
 export interface GameState {
+  phase: Phase;
   turn: { count: number; player: Player };
+  remainingMen: Record<Player, number>;
   stateGraph: StateGraph;
 }
 
@@ -49,27 +54,131 @@ export interface PlayAction extends BaseAction {
   to: PointID;
 }
 
+export interface PlaceAction extends BaseAction {
+  type: "place";
+  to: PointID;
+}
+
 interface ResetAction extends BaseAction {
   type: "reset";
 }
 
-type ActionType = "play" | "reset";
+type ActionType = "play" | "reset" | "place";
 interface BaseAction {
   type: ActionType;
 }
 
-type Action = PlayAction | ResetAction;
+type Action = PlayAction | ResetAction | PlaceAction;
 
-const otherPlayer = (player: Player): Player => {
+const getOtherPlayer = (player: Player): Player => {
   return player === "a" ? "b" : "a";
 };
 
+/**
+ * Validate a place action.
+ * Expected scenarios:
+ * - location must not be occupied
+ *
+ * Unexpected scenarios:
+ * - current player must have >= 1 remaining man
+ * - The game is not in phase 1
+ */
+const validatePlace = (action: PlaceAction, state: GameState): boolean => {
+  const currentPlayer = state.turn.player;
+  return (
+    state.stateGraph[action.to].occupancy === undefined &&
+    state.remainingMen[currentPlayer] >= 1 &&
+    state.phase === 1
+  );
+};
+
+/**
+ * Determine if the game state is in the next phase
+ */
+const isNextPhase = (state: GameState): boolean => {
+  switch (state.phase) {
+    // Phase 1 moves to phase 2 when there are no more remaining men
+    case 1:
+      return Object.values(state.remainingMen).every((rm) => rm === 0);
+
+    // TODO: Phase 2 moves to phase 3 when...
+    case 2:
+      return false;
+
+    // There is no phase 4, so the game can never advance from 3
+    case 3:
+      return false;
+
+    // All phases were covered above, so if we get here, something went wrong
+    default:
+      throw new Error(
+        `An invalid phase value of ${state.phase} was encountered in isNextPhase`
+      );
+  }
+};
+
+const incrementPhase = (phase: Phase): Phase => {
+  const nextPhase = phase + 1;
+
+  // This range should match the range defined in the Phase type
+  if (nextPhase > 3 || nextPhase < 1) {
+    throw new Error(
+      `An attempt to increment phase to ${nextPhase} was made. This is outside its valid range`
+    );
+  }
+  return nextPhase as Phase;
+};
+
 const reducer = (state: GameState, action: Action): GameState => {
+  const currentPlayer = state.turn.player;
+  const otherPlayer = getOtherPlayer(currentPlayer);
+
   switch (action.type) {
+    // A play in phase 1
+    case "place":
+      // Validate the place action
+      // TODO: How do we communicate the correct thing to do?
+      // TODO Should we validate before even allowing the action?
+      if (!validatePlace(action, state)) {
+        console.log("Invalid place action");
+        return state;
+      }
+
+      const newState = {
+        ...state,
+        stateGraph: {
+          ...state.stateGraph,
+
+          // Occupy the "to" location with the player who made this play
+          // TODO: check that it was valid
+          [action.to]: {
+            ...state.stateGraph[action.to],
+            occupancy: currentPlayer,
+          },
+        },
+        // When a play is made, the count increments and it becomes the other players turn
+        turn: {
+          player: otherPlayer,
+          count: state.turn.count + 1,
+        },
+
+        // Remove 1 man from the current players remaining men
+        remainingMen: {
+          ...state.remainingMen,
+          [currentPlayer]: state.remainingMen[currentPlayer] - 1,
+        },
+      };
+
+      // Check if the new state moves the game into the next phase
+      return isNextPhase(newState)
+        ? { ...newState, phase: incrementPhase(state.phase) }
+        : newState;
+
+    // A play in phase 2
     case "play":
-      const player = state.turn.player;
       // TODO: check for win
       return {
+        ...state,
         stateGraph: {
           ...state.stateGraph,
 
@@ -77,15 +186,17 @@ const reducer = (state: GameState, action: Action): GameState => {
           // TODO: make sure to move the from and check that it was valid
           [action.to]: {
             ...state.stateGraph[action.to],
-            occupancy: player,
+            occupancy: currentPlayer,
           },
         },
         // When a play is made, the count increments and it becomes the other players turn
         turn: {
-          player: otherPlayer(player),
+          player: otherPlayer,
           count: state.turn.count + 1,
         },
       };
+    // TODO Check if the new state moves the game into the next phase
+
     case "reset":
       return initialState;
     default:

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,4 +1,6 @@
 export const palette = {
   neutral: "grey",
+  neutralLight: "lightgray",
   primary: "#D2042D",
+  secondary: "blue",
 };

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,6 +1,7 @@
 export const palette = {
   neutral: "grey",
   neutralLight: "lightgray",
+  neutralDark: "#121212",
   primary: "#D2042D",
   secondary: "blue",
 };


### PR DESCRIPTION
I've
- defined the game including whos turn it is, how many turns there have been, what phase the game is in, how many men remain to be placed, and the neighbors and occupancy of every node (for 6 man morris)
- Updated the board to display occupancy and allow clicks to dispatch actions which update the game state
- Added a quick and dirty control panel to display phase, remaining men, and a reset button
- Added the ability to display the entire game state as json via adding "?debug" to the url

**All of the above supports playing the game correctly through phase 1**

> Note: forming mills will not be detected, removal of men, phase 2, and winning are all unsupported so far.


<img width="1081" alt="image" src="https://user-images.githubusercontent.com/28011772/168740100-233128d1-46e4-4366-ac61-da8a8a54baf0.png">
